### PR TITLE
Add Montoya message viewer support

### DIFF
--- a/src/main/kotlin/burp/MontoyaExtension.kt
+++ b/src/main/kotlin/burp/MontoyaExtension.kt
@@ -11,18 +11,34 @@ import burp.api.montoya.intruder.PayloadGenerator
 import burp.api.montoya.intruder.PayloadGeneratorProvider
 import burp.api.montoya.intruder.PayloadProcessingResult
 import burp.api.montoya.intruder.PayloadProcessor
+import burp.api.montoya.ui.Selection
+import burp.api.montoya.ui.editor.extension.EditorCreationContext
+import burp.api.montoya.ui.editor.extension.ExtensionProvidedEditor
+import burp.api.montoya.ui.editor.extension.ExtensionProvidedHttpRequestEditor
+import burp.api.montoya.ui.editor.extension.ExtensionProvidedHttpResponseEditor
+import burp.api.montoya.ui.editor.extension.HttpRequestEditorProvider
+import burp.api.montoya.ui.editor.extension.HttpResponseEditorProvider
 import burp.api.montoya.utilities.ByteUtils
 import java.awt.BorderLayout
+import java.awt.Component
 import java.io.BufferedReader
 import java.io.File
+import java.io.IOException
 import java.net.URL
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 import kotlin.text.Charsets
+import com.redpois0n.terminal.JTerminal
 import javax.swing.DefaultListModel
 import javax.swing.JTabbedPane
 import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.JScrollPane
+import javax.swing.JTextArea
+import javax.swing.SwingUtilities
 import javax.swing.event.ListDataEvent
 import javax.swing.event.ListDataListener
 
@@ -33,6 +49,7 @@ class MontoyaExtension : BurpExtension {
 
     private lateinit var processorManager: MontoyaRegisteredToolManager<Piper.MinimalTool>
     private lateinit var generatorManager: MontoyaRegisteredToolManager<Piper.MinimalTool>
+    private lateinit var messageViewerManager: MontoyaMessageViewerManager
 
     private val saveOnChangeListener = object : ListDataListener {
         override fun contentsChanged(e: ListDataEvent) = saveConfig()
@@ -77,6 +94,8 @@ class MontoyaExtension : BurpExtension {
             { it.enabled },
             { registerPayloadGenerator(it) }
         )
+
+        messageViewerManager = MontoyaMessageViewerManager(configModel.messageViewersModel)
 
         val queuePlaceholder = JPanel(BorderLayout()).apply {
             add(
@@ -133,6 +152,307 @@ class MontoyaExtension : BurpExtension {
         }
 
         return api.intruder().registerPayloadGeneratorProvider(provider)
+    }
+
+    private data class ViewerRegistrations(
+        val enabledFlag: AtomicBoolean,
+        val request: Registration?,
+        val response: Registration?,
+    ) {
+        fun deregister() {
+            enabledFlag.set(false)
+            request?.deregister()
+            response?.deregister()
+        }
+    }
+
+    private inner class MontoyaMessageViewerManager(
+        private val model: DefaultListModel<Piper.MessageViewer>,
+    ) : ListDataListener {
+
+        private val registrations: MutableList<ViewerRegistrations?> = mutableListOf()
+
+        init {
+            for (index in 0 until model.size()) {
+                registrations.add(registerViewer(model[index]))
+            }
+            model.addListDataListener(this)
+        }
+
+        private fun registerViewer(viewer: Piper.MessageViewer): ViewerRegistrations? {
+            if (!viewer.common.enabled) {
+                return null
+            }
+
+            val enabledFlag = AtomicBoolean(true)
+            val requestRegistration = if (viewer.common.scope != Piper.MinimalTool.Scope.RESPONSE_ONLY) {
+                api.userInterface().registerHttpRequestEditorProvider(
+                    MessageViewerRequestProvider(viewer, enabledFlag),
+                )
+            } else {
+                null
+            }
+            val responseRegistration = if (viewer.common.scope != Piper.MinimalTool.Scope.REQUEST_ONLY) {
+                api.userInterface().registerHttpResponseEditorProvider(
+                    MessageViewerResponseProvider(viewer, enabledFlag),
+                )
+            } else {
+                null
+            }
+            return ViewerRegistrations(enabledFlag, requestRegistration, responseRegistration)
+        }
+
+        override fun contentsChanged(e: ListDataEvent) {
+            for (index in e.index0..e.index1) {
+                registrations.getOrNull(index)?.deregister()
+                registrations[index] = registerViewer(model[index])
+            }
+            saveConfig()
+        }
+
+        override fun intervalAdded(e: ListDataEvent) {
+            for (index in e.index0..e.index1) {
+                registrations.add(index, registerViewer(model[index]))
+            }
+            saveConfig()
+        }
+
+        override fun intervalRemoved(e: ListDataEvent) {
+            for (index in e.index1 downTo e.index0) {
+                registrations.removeAt(index)?.deregister()
+            }
+            saveConfig()
+        }
+    }
+
+    private inner class MessageViewerRequestProvider(
+        private val viewer: Piper.MessageViewer,
+        private val enabledFlag: AtomicBoolean,
+    ) : HttpRequestEditorProvider {
+        override fun provideHttpRequestEditor(creationContext: EditorCreationContext?): ExtensionProvidedHttpRequestEditor {
+            return RequestMessageViewerEditor(viewer, enabledFlag)
+        }
+    }
+
+    private inner class MessageViewerResponseProvider(
+        private val viewer: Piper.MessageViewer,
+        private val enabledFlag: AtomicBoolean,
+    ) : HttpResponseEditorProvider {
+        override fun provideHttpResponseEditor(creationContext: EditorCreationContext?): ExtensionProvidedHttpResponseEditor {
+            return ResponseMessageViewerEditor(viewer, enabledFlag)
+        }
+    }
+
+    private abstract inner class BaseMessageViewerEditor(
+        protected val viewer: Piper.MessageViewer,
+        private val enabledFlag: AtomicBoolean,
+        private val handlesRequest: Boolean,
+    ) : ExtensionProvidedEditor {
+        private var current: burp.api.montoya.http.message.HttpRequestResponse? = null
+
+        override fun caption(): String = viewer.common.name
+        override fun isModified(): Boolean = false
+        override fun uiComponent(): Component = component()
+
+        override fun selectedData(): Selection? {
+            val bytes = selectedBytes() ?: return null
+            if (bytes.isEmpty()) return null
+            return Selection.selection(montoyaBytes(bytes))
+        }
+
+        override fun isEnabledFor(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): Boolean {
+            if (!enabledFlag.get() || !viewer.common.isInToolScope(handlesRequest)) {
+                return false
+            }
+
+            val messageBytes = messageBytes(requestResponse) ?: return false
+            val payload = buildPayload(messageBytes, requestResponse) ?: return false
+            if (payload.isEmpty()) {
+                return false
+            }
+
+            if (!viewer.common.hasFilter()) {
+                val cmd = viewer.common.cmd
+                return !cmd.hasFilter || cmd.matches(payload, context)
+            }
+
+            val info = MessageInfo(
+                payload,
+                context.bytesToString(payload),
+                headers(requestResponse),
+                url(requestResponse),
+            )
+            return viewer.common.filter.matches(info, context)
+        }
+
+        override fun setRequestResponse(requestResponse: burp.api.montoya.http.message.HttpRequestResponse) {
+            current = requestResponse
+            val messageBytes = messageBytes(requestResponse)
+            val payload = if (messageBytes == null) null else buildPayload(messageBytes, requestResponse)
+            if (payload == null) {
+                resetUi()
+                return
+            }
+
+            thread(start = true) {
+                try {
+                    viewer.common.cmd.execute(payload).processOutput { process ->
+                        processOutput(process)
+                    }
+                } catch (e: IOException) {
+                    handleExecutionFailure(e)
+                }
+            }
+        }
+
+        protected fun currentMessage(): burp.api.montoya.http.message.HttpRequestResponse? = current
+
+        protected fun montoyaBytes(bytes: kotlin.ByteArray): ByteArray =
+            ByteArray.byteArray(*bytes.map { it.toInt() }.toIntArray())
+
+        protected fun logError(message: String) {
+            api.logging().logToError(message)
+        }
+
+        protected fun bytesToString(bytes: kotlin.ByteArray): String =
+            api.utilities().byteUtils().convertToString(bytes)
+
+        protected fun parseUrl(value: String?): URL? =
+            value?.let { runCatching { URL(it) }.getOrNull() }
+
+        private fun buildPayload(
+            content: kotlin.ByteArray,
+            requestResponse: burp.api.montoya.http.message.HttpRequestResponse,
+        ): kotlin.ByteArray? {
+            if (viewer.common.cmd.passHeaders) {
+                return content
+            }
+            val offset = bodyOffset(requestResponse) ?: return null
+            if (offset >= content.size) {
+                return null
+            }
+            return content.copyOfRange(offset, content.size)
+        }
+
+        protected abstract fun component(): Component
+        protected abstract fun messageBytes(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): kotlin.ByteArray?
+        protected abstract fun bodyOffset(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): Int?
+        protected abstract fun headers(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): List<String>?
+        protected abstract fun url(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): URL?
+        protected abstract fun processOutput(process: Process)
+        protected abstract fun handleExecutionFailure(e: IOException)
+        protected abstract fun resetUi()
+        protected abstract fun selectedBytes(): kotlin.ByteArray?
+    }
+
+    private inner class RequestMessageViewerEditor(
+        viewer: Piper.MessageViewer,
+        enabledFlag: AtomicBoolean,
+    ) : BaseMessageViewerEditor(viewer, enabledFlag, true), ExtensionProvidedHttpRequestEditor {
+        private val textArea = JTextArea().apply { isEditable = false }
+        private val scrollPane = JScrollPane(textArea)
+
+        override fun getRequest(): burp.api.montoya.http.message.requests.HttpRequest {
+            return currentMessage()?.request() ?: burp.api.montoya.http.message.requests.HttpRequest.httpRequest()
+        }
+
+        override fun component(): Component = scrollPane
+
+        override fun messageBytes(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): kotlin.ByteArray? {
+            return requestResponse.request()?.toByteArray()?.getBytes()
+        }
+
+        override fun bodyOffset(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): Int? =
+            requestResponse.request()?.bodyOffset()
+
+        override fun headers(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): List<String>? =
+            requestResponse.request()?.headers()?.map { it.toString() }
+
+        override fun url(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): URL? =
+            parseUrl(requestResponse.request()?.url())
+
+        override fun processOutput(process: Process) {
+            val output = process.inputStream.use { it.readBytes() }
+            process.errorStream.use { it.readBytes() }
+            SwingUtilities.invokeLater { textArea.text = bytesToString(output) }
+        }
+
+        override fun handleExecutionFailure(e: IOException) {
+            val message = "Failed to execute ${viewer.common.cmd.commandLine}: ${e.message}"
+            SwingUtilities.invokeLater { textArea.text = message }
+            logError(message)
+        }
+
+        override fun resetUi() {
+            SwingUtilities.invokeLater { textArea.text = "" }
+        }
+
+        override fun selectedBytes(): kotlin.ByteArray? = textArea.selectedText?.toByteArray()
+    }
+
+    private inner class ResponseMessageViewerEditor(
+        viewer: Piper.MessageViewer,
+        enabledFlag: AtomicBoolean,
+    ) : BaseMessageViewerEditor(viewer, enabledFlag, false), ExtensionProvidedHttpResponseEditor {
+        private val terminal = JTerminal()
+        private val scrollPane = JScrollPane(terminal)
+
+        override fun getResponse(): burp.api.montoya.http.message.responses.HttpResponse {
+            return currentMessage()?.response() ?: burp.api.montoya.http.message.responses.HttpResponse.httpResponse()
+        }
+
+        override fun component(): Component = scrollPane
+
+        override fun messageBytes(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): kotlin.ByteArray? {
+            if (!requestResponse.hasResponse()) {
+                return null
+            }
+            return requestResponse.response()?.toByteArray()?.getBytes()
+        }
+
+        override fun bodyOffset(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): Int? =
+            requestResponse.response()?.bodyOffset()
+
+        override fun headers(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): List<String>? =
+            requestResponse.response()?.headers()?.map { it.toString() }
+
+        override fun url(requestResponse: burp.api.montoya.http.message.HttpRequestResponse): URL? =
+            parseUrl(requestResponse.url())
+
+        override fun processOutput(process: Process) {
+            terminal.text = ""
+            val readers = listOf(process.inputStream.bufferedReader(), process.errorStream.bufferedReader())
+            val latch = CountDownLatch(readers.size)
+            readers.forEach { reader ->
+                thread(start = true) {
+                    try {
+                        while (true) {
+                            val line = reader.readLine() ?: break
+                            SwingUtilities.invokeLater { terminal.append("$line\n") }
+                        }
+                    } finally {
+                        latch.countDown()
+                        reader.close()
+                    }
+                }
+            }
+            latch.await()
+        }
+
+        override fun handleExecutionFailure(e: IOException) {
+            val message = "Failed to execute ${viewer.common.cmd.commandLine}: ${e.message}"
+            SwingUtilities.invokeLater {
+                terminal.text = ""
+                terminal.append("$message\n")
+            }
+            logError(message)
+        }
+
+        override fun resetUi() {
+            SwingUtilities.invokeLater { terminal.text = "" }
+        }
+
+        override fun selectedBytes(): kotlin.ByteArray? = terminal.selectedText?.toByteArray()
     }
 
     private inner class PiperPayloadGenerator(private val tool: Piper.MinimalTool) : PayloadGenerator {


### PR DESCRIPTION
## Summary
- register and manage message viewers through the Montoya API
- implement a shared Montoya editor base that evaluates filters and streams command output
- provide request and response viewer implementations using text and terminal components

## Testing
- ./gradlew build --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e609776a6083228af34bdbd43b0069