### PR TITLE
Add interactive parameter support for intruder generators

### DIFF
--- a/src/main/kotlin/burp/CommandParameters.kt
+++ b/src/main/kotlin/burp/CommandParameters.kt
@@ -1,0 +1,161 @@
+package burp
+
+import java.awt.Component
+import java.awt.GridBagConstraints
+import java.awt.Insets
+import java.util.Locale
+import javax.swing.JLabel
+import javax.swing.JOptionPane
+import javax.swing.JPanel
+import javax.swing.JTextField
+
+private val PLACEHOLDER_REGEX = Regex("\\$\\{([A-Za-z0-9_]+)}")
+private const val ENVIRONMENT_PREFIX = "PIPER_PARAM_"
+
+val Piper.CommandInvocation.Parameter.displayName: String
+    get() = if (label.isNullOrBlank()) name else label
+
+fun Piper.CommandInvocation.Parameter.descriptionOrNull(): String? =
+    if (description.isNullOrBlank()) null else description
+
+fun Piper.CommandInvocation.resolveParameterValues(provided: Map<String, String>): Map<String, String> {
+    if (parameterCount == 0 && provided.isEmpty()) {
+        return emptyMap()
+    }
+    val resolved = linkedMapOf<String, String>()
+    val missing = mutableListOf<String>()
+    for (parameter in parameterList) {
+        val key = parameter.name
+        val providedValue = provided[key]
+        val finalValue = when {
+            !providedValue.isNullOrEmpty() -> providedValue
+            !parameter.defaultValue.isNullOrEmpty() -> parameter.defaultValue
+            else -> ""
+        }
+        if (finalValue.isEmpty() && parameter.required) {
+            missing += parameter.displayName
+        }
+        resolved[key] = finalValue
+    }
+    if (missing.isNotEmpty()) {
+        throw IllegalArgumentException("Missing required parameters: ${missing.joinToString(", ")}")
+    }
+    for ((key, value) in provided) {
+        if (!resolved.containsKey(key)) {
+            resolved[key] = value
+        }
+    }
+    return resolved
+}
+
+fun String.containsParameterPlaceholder(): Boolean = PLACEHOLDER_REGEX.containsMatchIn(this)
+
+fun String.applyParameters(parameters: Map<String, String>): String {
+    if (parameters.isEmpty()) {
+        return this
+    }
+    return PLACEHOLDER_REGEX.replace(this) { matchResult ->
+        val key = matchResult.groupValues[1]
+        parameters[key]
+            ?: throw IllegalArgumentException("No value provided for parameter \"$key\"")
+    }
+}
+
+fun Piper.CommandInvocation.applyParametersTo(args: List<String>, parameters: Map<String, String>): List<String> =
+    args.map { it.applyParameters(parameters) }
+
+fun Piper.CommandInvocation.parameterEnvironment(parameters: Map<String, String>): Map<String, String> {
+    if (parameters.isEmpty()) {
+        return emptyMap()
+    }
+    return parameters.mapKeys { (key, _) ->
+        ENVIRONMENT_PREFIX + key.uppercase(Locale.ROOT)
+    }
+}
+
+fun promptForCommandParameters(
+    parent: Component?,
+    toolName: String,
+    command: Piper.CommandInvocation,
+): Map<String, String>? {
+    if (command.parameterCount == 0) {
+        return emptyMap()
+    }
+    val parameters = command.parameterList
+    val values = linkedMapOf<String, String>()
+    for (parameter in parameters) {
+        values[parameter.name] = parameter.defaultValue.orEmpty()
+    }
+    while (true) {
+        val (panel, fields) = buildParameterPromptPanel(parameters, values)
+        val option = JOptionPane.showConfirmDialog(
+            parent,
+            panel,
+            "Parameters for $toolName",
+            JOptionPane.OK_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE,
+        )
+        if (option != JOptionPane.OK_OPTION) {
+            return null
+        }
+        var error: String? = null
+        for (parameter in parameters) {
+            val fieldValue = fields[parameter.name]!!.text
+            val finalValue = if (fieldValue.isEmpty()) parameter.defaultValue.orEmpty() else fieldValue
+            if (finalValue.isEmpty() && parameter.required) {
+                error = "\"${parameter.displayName}\" is required."
+                break
+            }
+            values[parameter.name] = finalValue
+        }
+        if (error == null) {
+            return parameters.associate { it.name to values[it.name].orEmpty() }
+        }
+        JOptionPane.showMessageDialog(parent, error, "Missing value", JOptionPane.ERROR_MESSAGE)
+    }
+}
+
+private fun buildParameterPromptPanel(
+    parameters: List<Piper.CommandInvocation.Parameter>,
+    currentValues: Map<String, String>,
+): Pair<JPanel, Map<String, JTextField>> {
+    val panel = JPanel(java.awt.GridBagLayout())
+    val constraints = GridBagConstraints().apply {
+        gridx = 0
+        gridy = 0
+        insets = Insets(4, 4, 4, 4)
+        fill = GridBagConstraints.HORIZONTAL
+        weightx = 1.0
+    }
+    val fields = linkedMapOf<String, JTextField>()
+    for (parameter in parameters) {
+        val displayName = buildString {
+            append(parameter.displayName)
+            if (parameter.required && parameter.defaultValue.isNullOrEmpty()) {
+                append(" *")
+            }
+        }
+        val label = JLabel(displayName)
+        panel.add(label, constraints)
+        constraints.gridx = 1
+        val field = JTextField(currentValues[parameter.name] ?: "")
+        field.columns = 30
+        panel.add(field, constraints)
+        fields[parameter.name] = field
+        constraints.gridx = 0
+        constraints.gridy++
+        val description = parameter.descriptionOrNull()
+        if (description != null) {
+            val descriptionLabel = JLabel("<html><i>${description.replace("\n", "<br>")}</i></html>")
+            constraints.gridwidth = 2
+            panel.add(descriptionLabel, constraints)
+            constraints.gridwidth = 1
+            constraints.gridy++
+        }
+    }
+    constraints.gridwidth = 2
+    constraints.gridx = 0
+    val helper = JLabel("Use placeholders like \\\"${'$'}{name}\\\" in the command to reference the values.")
+    panel.add(helper, constraints)
+    return panel to fields
+}

--- a/src/main/kotlin/burp/Serialization.kt
+++ b/src/main/kotlin/burp/Serialization.kt
@@ -84,8 +84,21 @@ fun commandInvocationFromMap(source: Map<String, Any>): Piper.CommandInvocation 
         copyBooleanFlag("passHeaders", b::setPassHeaders)
         copyStructured("stdout", b::setStdout, ::messageMatchFromMap)
         copyStructured("stderr", b::setStderr, ::messageMatchFromMap)
+        copyListOfStructured("parameters", b::addParameter, ::commandParameterFromMap)
     }
     return b.build()
+}
+
+fun commandParameterFromMap(source: Map<String, Any>): Piper.CommandInvocation.Parameter {
+    val builder = Piper.CommandInvocation.Parameter.newBuilder()
+            .setName(source.stringOrDie("name"))
+    (source["label"] as? String)?.let(builder::setLabel)
+    (source["description"] as? String)?.let(builder::setDescription)
+    (source["defaultValue"] as? String)?.let(builder::setDefaultValue)
+    if (source["required"] == true) {
+        builder.required = true
+    }
+    return builder.build()
 }
 
 fun messageMatchFromMap(source: Map<String, Any>): Piper.MessageMatch {
@@ -320,7 +333,17 @@ fun Piper.CommandInvocation.toMap(): MutableMap<String, Any> {
     if (this.exitCodeCount > 0) m["exitCode"] = this.exitCodeList
     if (this.hasStdout()) m["stdout"] = this.stdout.toMap()
     if (this.hasStderr()) m["stderr"] = this.stderr.toMap()
+    if (this.parameterCount > 0) m["parameters"] = this.parameterList.map(Piper.CommandInvocation.Parameter::toMap)
     return m
+}
+
+fun Piper.CommandInvocation.Parameter.toMap(): MutableMap<String, Any> {
+    val map = mutableMapOf<String, Any>("name" to this.name)
+    if (!this.label.isNullOrEmpty()) map["label"] = this.label
+    if (!this.description.isNullOrEmpty()) map["description"] = this.description
+    if (!this.defaultValue.isNullOrEmpty()) map["defaultValue"] = this.defaultValue
+    if (this.required) map["required"] = true
+    return map
 }
 
 fun Piper.RegularExpression.toMap(): Map<String, Any> {

--- a/src/main/proto/burp/piper.proto
+++ b/src/main/proto/burp/piper.proto
@@ -43,6 +43,14 @@ message CommandInvocation {
     repeated int32 exitCode = 6;
     MessageMatch stdout = 7;
     MessageMatch stderr = 8;
+    message Parameter {
+        string name = 1;
+        string label = 2;
+        string description = 3;
+        string defaultValue = 4;
+        bool required = 5;
+    }
+    repeated Parameter parameter = 9;
 }
 
 message MessageMatch {


### PR DESCRIPTION
## Summary
- add command invocation parameter definitions, including placeholder substitution and environment exposure for scripts
- extend the configuration UI and serialization to manage interactive parameter metadata
- prompt intruder payload generators (legacy and Montoya) for parameter values before invoking external tools

## Testing
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e60ec9c2308322bcf6f3c78a12a82b